### PR TITLE
User-only permissions for tempfiles

### DIFF
--- a/src/tempfile.rs
+++ b/src/tempfile.rs
@@ -1,4 +1,5 @@
-use std::fs::{self, File};
+use std::fs::{self, Permissions, File};
+use std::os::unix::prelude::*;
 use std::ops::{Deref, DerefMut, Drop};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -22,6 +23,7 @@ impl Tempfile {
         let filename = format!("{}{}{}", prefix.as_ref(), nanos, suffix.as_ref());
         let path = base_dir.as_ref().join(filename);
         let file = File::create(&path)?;
+        fs::set_permissions(&path, Permissions::from_mode(0o600))?;
         Ok(Tempfile {
             file: Some(file),
             path: path,


### PR DESCRIPTION
Fixes https://github.com/sbstp/kubie/issues/14

```
ls -l /tmp/|grep kubie
-rw-------  1 pierre  wheel     590  4 avr 03:21 kubie-bashrc-1585984900875479000.bash
-rw-------  1 pierre  wheel    2547  4 avr 03:21 kubie-config1585984900873043000.yaml
-rw-------  1 pierre  wheel     105  4 avr 03:21 kubie-session1585984900875121000.yaml
```