### PR TITLE
preemptively set KUBECONFIG

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -62,6 +62,9 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
     let next_depth = depth + 1;
 
     let mut env_vars = EnvVars::new();
+    // pre-insert the KUBECONFIG variable into the shell.
+    // This will make sure any shell plugins/add-ons which require this env variable will have it available at the beginninng of the .rc file
+    env_vars.insert("KUBECONFIG", temp_config_file.path());
     env_vars.insert("KUBIE_ACTIVE", "1");
     env_vars.insert("KUBIE_DEPTH", next_depth.to_string());
     env_vars.insert("KUBIE_KUBECONFIG", temp_config_file.path());


### PR DESCRIPTION
In #18 I mentioned in a [comment](https://github.com/sbstp/kubie/issues/18#issuecomment-609477575) that there was a race causing starship to not load with the proper data. It turned out to be that the `KUBECOFIG` variable was not being set in the shell until the end of the `.rc` file, which may be after many other plugins have loaded, at least in the case of `zsh`.

This PR simply preemptively sets the `KUBECONFIG` env var so it is available to the entirety of the `.zshrc` file. 
