### PR TITLE
Add fish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,13 @@ prompt:
     # Default: true
     show_depth: true
 
-    # When using zsh, show context and namespace on the right side using RPS1.
+    # When using zsh, show context and namespace on the right-hand side using RPS1.
     # Default: false
     zsh_use_rps1: false
+
+    # When using fish, show context and namespace on the right-hand side.
+    # Default: false
+    fish_use_rprompt: false
 ```
 
 ## Future plans

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -133,6 +133,8 @@ pub struct Prompt {
     pub show_depth: bool,
     #[serde(default = "def_bool_false")]
     pub zsh_use_rps1: bool,
+    #[serde(default = "def_bool_false")]
+    pub fish_use_rprompt: bool,
 }
 
 impl Default for Prompt {
@@ -141,6 +143,7 @@ impl Default for Prompt {
             disable: false,
             show_depth: true,
             zsh_use_rps1: false,
+            fish_use_rprompt: false,
         }
     }
 }

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -1,0 +1,62 @@
+use std::process::Command;
+
+use anyhow::Result;
+
+use super::ShellSpawnInfo;
+
+pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
+    let mut cmd = Command::new("fish");
+    cmd.arg("-C");
+    cmd.arg(format!(
+        r#"
+# Set the proper KUBECONFIG variable before each command runs,
+# to prevent the user from overwriting it.
+function kubie_preexec --on-event fish_preexec
+    set -xg KUBECONFIG "$KUBIE_KUBECONFIG"
+end
+
+if test "$KUBIE_PROMPT_DISABLE" = "1"
+    return 0
+end
+
+# The general idea behind the prompt substitions is to save the existing
+# prompt's output _before_ anything else is run. This is important since the
+# existing prompt might be dependent on say the status of the executed command.
+
+if test "$KUBIE_ZSH_USE_RPS1" = "1"
+    functions -q fish_right_prompt
+    and functions --copy fish_right_prompt fish_right_prompt_original
+    or function fish_right_prompt_original; end
+
+    function fish_right_prompt
+        set -l original (fish_right_prompt_original)
+
+        # Fish's right prompt does not support newlines, so there's no point in
+        # iterating through the (potentially) existing prompt's lines.
+        printf '%s %s' (string unescape {prompt}) $original
+    end
+else
+    functions --copy fish_prompt fish_prompt_original
+    function fish_prompt
+        set -l original (fish_prompt_original)
+
+        printf '%s ' (string unescape {prompt})
+
+        # Due to idiosyncrasies with the way fish is managing newlines in
+        # process substitions, each line needs to be printed separately
+        # to mirror the existing output. For more details,
+        # see https://github.com/fish-shell/fish-shell/issues/159.
+        for line in $original
+            echo -e $line
+        end
+    end
+end
+    "#,
+        prompt = info.prompt,
+    ));
+    info.env_vars.apply(&mut cmd);
+
+    let mut child = cmd.spawn()?;
+    child.wait()?;
+    Ok(())
+}

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -15,39 +15,37 @@ function kubie_preexec --on-event fish_preexec
     set -xg KUBECONFIG "$KUBIE_KUBECONFIG"
 end
 
-if test "$KUBIE_PROMPT_DISABLE" = "1"
-    return 0
-end
+if test "$KUBIE_PROMPT_DISABLE" = "0"
+    # The general idea behind the prompt substitions is to save the existing
+    # prompt's output _before_ anything else is run. This is important since the
+    # existing prompt might be dependent on say the status of the executed command.
 
-# The general idea behind the prompt substitions is to save the existing
-# prompt's output _before_ anything else is run. This is important since the
-# existing prompt might be dependent on say the status of the executed command.
+    if test "$KUBIE_FISH_USE_RPROMPT" = "1"
+        functions -q fish_right_prompt
+        and functions --copy fish_right_prompt fish_right_prompt_original
+        or function fish_right_prompt_original; end
 
-if test "$KUBIE_ZSH_USE_RPS1" = "1"
-    functions -q fish_right_prompt
-    and functions --copy fish_right_prompt fish_right_prompt_original
-    or function fish_right_prompt_original; end
+        function fish_right_prompt
+            set -l original (fish_right_prompt_original)
 
-    function fish_right_prompt
-        set -l original (fish_right_prompt_original)
+            # Fish's right prompt does not support newlines, so there's no point in
+            # iterating through the (potentially) existing prompt's lines.
+            printf '%s %s' (string unescape {prompt}) $original
+        end
+    else
+        functions --copy fish_prompt fish_prompt_original
+        function fish_prompt
+            set -l original (fish_prompt_original)
 
-        # Fish's right prompt does not support newlines, so there's no point in
-        # iterating through the (potentially) existing prompt's lines.
-        printf '%s %s' (string unescape {prompt}) $original
-    end
-else
-    functions --copy fish_prompt fish_prompt_original
-    function fish_prompt
-        set -l original (fish_prompt_original)
+            printf '%s ' (string unescape {prompt})
 
-        printf '%s ' (string unescape {prompt})
-
-        # Due to idiosyncrasies with the way fish is managing newlines in
-        # process substitions, each line needs to be printed separately
-        # to mirror the existing output. For more details,
-        # see https://github.com/fish-shell/fish-shell/issues/159.
-        for line in $original
-            echo -e $line
+            # Due to idiosyncrasies with the way fish is managing newlines in
+            # process substitions, each line needs to be printed separately
+            # to mirror the existing output. For more details,
+            # see https://github.com/fish-shell/fish-shell/issues/159.
+            for line in $original
+                echo -e $line
+            end
         end
     end
 end

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -14,6 +14,7 @@ use crate::vars;
 
 mod bash;
 mod detect;
+mod fish;
 mod prompt;
 mod zsh;
 
@@ -103,7 +104,7 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
 
     match kind {
         ShellKind::Bash => bash::spawn_shell(&info),
+        ShellKind::Fish => fish::spawn_shell(&info),
         ShellKind::Zsh => zsh::spawn_shell(&info),
-        _ => bash::spawn_shell(&info),
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -83,6 +83,10 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
         "KUBIE_ZSH_USE_RPS1",
         if settings.prompt.zsh_use_rps1 { "1" } else { "0" },
     );
+    env_vars.insert(
+        "KUBIE_FISH_USE_RPROMPT",
+        if settings.prompt.fish_use_rprompt { "1" } else { "0" },
+    );
 
     match kind {
         ShellKind::Bash => {

--- a/src/shell/prompt.rs
+++ b/src/shell/prompt.rs
@@ -6,19 +6,24 @@ use crate::shell::ShellKind;
 
 struct Command {
     content: String,
+    shell_kind: ShellKind,
 }
 
 impl Command {
-    fn new(content: impl Into<String>) -> Command {
+    fn new(content: impl Into<String>, shell_kind: ShellKind) -> Command {
         Command {
             content: content.into(),
+            shell_kind,
         }
     }
 }
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "$({})", self.content)
+        match self.shell_kind {
+            ShellKind::Fish => write!(f, "({})", self.content),
+            _ => write!(f, "$({})", self.content),
+        }
     }
 }
 
@@ -47,6 +52,7 @@ where
         E: Display,
     {
         match self.shell_kind {
+            ShellKind::Fish => write!(f, "{}", content),
             ShellKind::Zsh => write!(f, "%{{{}%}}", content),
             _ => write!(f, "\\[{}\\]", content),
         }
@@ -89,7 +95,7 @@ pub fn generate_ps1(settings: &Settings, depth: u32, shell_kind: ShellKind) -> S
     parts.push(
         Color::new(
             RED,
-            Command::new(format!("{} info ctx", current_exe_path_str)),
+            Command::new(format!("{} info ctx", current_exe_path_str), shell_kind),
             shell_kind,
         )
         .to_string(),
@@ -97,7 +103,7 @@ pub fn generate_ps1(settings: &Settings, depth: u32, shell_kind: ShellKind) -> S
     parts.push(
         Color::new(
             GREEN,
-            Command::new(format!("{} info ns", current_exe_path_str)),
+            Command::new(format!("{} info ns", current_exe_path_str), shell_kind),
             shell_kind,
         )
         .to_string(),


### PR DESCRIPTION
Hi 👋

This PR introduces fish support. I did not add completion support, but if this is accepted I'm considering looking into that as well at some point. This should fix #17.

I've reused the prompt for bash/zsh for simplicity's sake. This could definitely be improved in the future by having a more generic structure for constructing the prompt based on the output of the `kubie info` commands and a set of colors.

This change was verified with my fish prompt based on starship.rs, and while it works, it's not prepending it on the same line. This is because of the starship prompt is outputting a clearing ANSI escape code. (It would be possible to check for the existence of that code and inject the prompt after it, effectively ending up where one would expect the prompt to be, though I'm not convinced that type of logic belongs in Kubie.) The outcome is exactly the same as in [this comment](https://github.com/sbstp/kubie/issues/18#issuecomment-609477575).

The right-side prompt works as expected, though. I reused the zsh RPS1 setting for determining whether right-side prompt is enabled. It would feel redundant to have one right-prompt setting per shell, but OTOH the current name is hard-tied to zsh.