### PR TITLE
Run fish as an interactive login shell

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -6,7 +6,8 @@ use super::ShellSpawnInfo;
 
 pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
     let mut cmd = Command::new("fish");
-    cmd.arg("-C");
+    // run fish as an interactive login shell
+    cmd.arg("-ilC");
     cmd.arg(format!(
         r#"
 # Set the proper KUBECONFIG variable before each command runs,


### PR DESCRIPTION
Since kubie is used in an interactive context, the proper way to spawn a
shell should be to pass in the interactive and login flags to it (I
think). I noticed that ctrl+c for instance behaved weirdly in fish when
not setting the spawned shell as interactive and login.