### PR TITLE
Add support for unsetting namespace

### DIFF
--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -14,7 +14,7 @@ pub fn info(info: KubieInfo) -> Result<()> {
         KubieInfoKind::Namespace => {
             vars::ensure_kubie_active()?;
             let conf = kubeconfig::get_current_config()?;
-            println!("{}", conf.contexts[0].context.namespace);
+            println!("{}", conf.contexts[0].context.namespace.as_deref().unwrap_or("default"));
         }
         KubieInfoKind::Depth => {
             vars::ensure_kubie_active()?;

--- a/src/cmd/meta.rs
+++ b/src/cmd/meta.rs
@@ -32,6 +32,10 @@ pub enum Kubie {
         #[structopt(short = "r", long = "recursive")]
         recursive: bool,
 
+        /// Unsets the namespace in the currently active context.
+        #[structopt(short = "u", long = "unset")]
+        unset: bool,
+
         /// Name of the namespace to enter. Use '-' to switch back to the previous namespace.
         namespace_name: Option<String>,
     },

--- a/src/cmd/namespace.rs
+++ b/src/cmd/namespace.rs
@@ -11,56 +11,63 @@ use crate::shell::spawn_shell;
 use crate::state::State;
 use crate::vars;
 
-pub fn namespace(settings: &Settings, namespace_name: Option<String>, recursive: bool) -> Result<()> {
+pub fn namespace(settings: &Settings, namespace_name: Option<String>, recursive: bool, unset: bool) -> Result<()> {
     vars::ensure_kubie_active()?;
+
+    let mut session = Session::load().context("Could not load session file")?;
+
+    if namespace_name.is_none() && unset {
+        return enter_namespace(settings, &mut session, recursive, None);
+    }
 
     let namespaces = kubectl::get_namespaces(None)?;
 
-    let enter_namespace = |mut namespace_name: String| -> Result<()> {
-        let mut session = Session::load().context("Could not load session file")?;
-
-        if namespace_name == "-" {
-            namespace_name = session
+    let namespace_name = match namespace_name {
+        Some(s) if s == "-" => Some(
+            session
                 .get_last_namespace()
                 .context("There is not previous namespace to switch to")?
-                .to_string();
-        } else if !namespaces.contains(&namespace_name) {
-            return Err(anyhow!("'{}' is not a valid namespace for the context", namespace_name));
-        }
-
-        let mut config = kubeconfig::get_current_config()?;
-        config.contexts[0].context.namespace = namespace_name.clone();
-
-        let context_name = &config.contexts[0].name;
-
-        // Update the state, set the last namespace used for the context.
-        let mut state = State::load().context("Could not load state file.")?;
-        state
-            .namespace_history
-            .insert(context_name.into(), namespace_name.clone());
-        state.save()?;
-
-        // Update the history, add the context and namespace to it.
-        session.add_history_entry(context_name, namespace_name);
-
-        if recursive {
-            spawn_shell(settings, config, &session)?;
-        } else {
-            let config_file = File::create(kubeconfig::get_kubeconfig_path()?)?;
-            config.write_to(config_file)?;
-            session.save(None)?;
-        }
-
-        Ok(())
-    };
-
-    let namespace_name = match namespace_name {
-        Some(namespace_name) => namespace_name,
+                .to_string(),
+        ),
+        Some(s) if !namespaces.contains(&s) => return Err(anyhow!("'{}' is not a valid namespace for the context", s)),
         None => match select_or_list_namespace()? {
-            SelectResult::Selected(x) => x,
+            SelectResult::Selected(s) => Some(s),
             _ => return Ok(()),
         },
+        Some(_) => namespace_name,
     };
 
-    enter_namespace(namespace_name)
+    enter_namespace(settings, &mut session, recursive, namespace_name)
+}
+
+fn enter_namespace(
+    settings: &Settings,
+    session: &mut Session,
+    recursive: bool,
+    namespace_name: Option<String>,
+) -> Result<()> {
+    let mut config = kubeconfig::get_current_config()?;
+    config.contexts[0].context.namespace = namespace_name.clone();
+
+    let context_name = &config.contexts[0].name;
+
+    // Update the state, set the last namespace used for the context.
+    let mut state = State::load().context("Could not load state file.")?;
+    state
+        .namespace_history
+        .insert(context_name.into(), namespace_name.clone());
+    state.save()?;
+
+    // Update the history, add the context and namespace to it.
+    session.add_history_entry(context_name, namespace_name);
+
+    if recursive {
+        spawn_shell(settings, config, &session)?;
+    } else {
+        let config_file = File::create(kubeconfig::get_kubeconfig_path()?)?;
+        config.write_to(config_file)?;
+        session.save(None)?;
+    }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,9 @@ fn main() -> Result<()> {
         Kubie::Namespace {
             namespace_name,
             recursive,
+            unset,
         } => {
-            cmd::namespace::namespace(&settings, namespace_name, recursive)?;
+            cmd::namespace::namespace(&settings, namespace_name, recursive, unset)?;
         }
         Kubie::Info(info) => {
             cmd::info::info(info)?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,10 +44,10 @@ impl Session {
         ioutil::write_json(session_path, self)
     }
 
-    pub fn add_history_entry(&mut self, context: impl Into<String>, namespace: impl Into<String>) {
+    pub fn add_history_entry(&mut self, context: impl Into<String>, namespace: Option<impl Into<String>>) {
         self.history.push(HistoryEntry {
             context: context.into(),
-            namespace: namespace.into(),
+            namespace: namespace.map(Into::into),
         })
     }
 
@@ -68,7 +68,7 @@ impl Session {
                 return None;
             }
             if current_context.namespace != entry.namespace {
-                return Some(&entry.namespace);
+                return entry.namespace.as_deref();
             }
         }
         None
@@ -78,5 +78,5 @@ impl Session {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HistoryEntry {
     pub context: String,
-    pub namespace: String,
+    pub namespace: Option<String>,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,7 +26,7 @@ pub struct State {
     /// when the context is entered again.
     ///
     /// The key represents the name of the context and the value is the namespace's name.
-    pub namespace_history: HashMap<String, String>,
+    pub namespace_history: HashMap<String, Option<String>>,
 }
 
 impl State {


### PR DESCRIPTION
`kubie ns -u` or `kubie ns --unset` will unset the currently active namespace. It also does not set namespace at all by default (matching e.g. `kubectx`) behavior. The original motivation was to get rid of my prompt saying `context:default`; with this change I can now have the prompt display just `context` and that will be the default for new contexts without session history.