### PR TITLE
Fix autocomplete error

### DIFF
--- a/completion/kubie.bash
+++ b/completion/kubie.bash
@@ -6,7 +6,6 @@ _kubiecomplete()
 
     cur=${COMP_WORDS[COMP_CWORD]}
     prev=${COMP_WORDS[COMP_CWORD-1]}
-    prevprev=${COMP_WORDS[COMP_CWORD-2]}
 
     { \unalias command; \unset -f command; } >/dev/null 2>&1 || true
 
@@ -32,6 +31,7 @@ _kubiecomplete()
             esac
             ;;
         3)
+            prevprev=${COMP_WORDS[COMP_CWORD-2]}
             case ${prevprev} in
                 exec)
                     COMPREPLY=($(command kubie exec ${prev} default kubectl get namespaces|command tail -n+2|command awk '{print $1}'| command grep -e "^$cur" |command xargs))


### PR DESCRIPTION
When using autocomplete with just the command, so when pressing <kbd>TAB</kbd> with just the command written:

```sh
$ kubie [TAB-KEY]
```

The following bash error is shown:

```sh
$ kubie [TAB-KEY]-bash: COMP_WORDS: bad array subscript
```

A similar error pops up when starting to write the first command, messing up the autocomplete output:

```sh
$ kubie [TAB-KEY]-bash: COMP_WORDS: bad array subscript
  kubie c-bash: COMP_WORDS: bad array subscript
tx
``

This little fix makes sure that the command does not show any error in either cases.

