### PR TITLE
add xonsh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ available below.
 
 ```yaml
 # Force kubie to use a particular shell, if unset detect shell currently in use.
-# Possible values: bash, dash, fish, zsh
+# Possible values: bash, dash, fish, xonsh, zsh
 # Default: unset
 shell: bash
 
@@ -122,6 +122,10 @@ prompt:
     # When using fish, show context and namespace on the right-hand side.
     # Default: false
     fish_use_rprompt: false
+
+    # When using xonsh, show context and namespace on the right-hand side.
+    # Default: false
+    xonsh_use_right_prompt: false
 
 # Behavior
 behavior:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -139,6 +139,8 @@ pub struct Prompt {
     pub zsh_use_rps1: bool,
     #[serde(default = "def_bool_false")]
     pub fish_use_rprompt: bool,
+    #[serde(default = "def_bool_false")]
+    pub xonsh_use_right_prompt: bool,
 }
 
 impl Default for Prompt {
@@ -148,6 +150,7 @@ impl Default for Prompt {
             show_depth: true,
             zsh_use_rps1: false,
             fish_use_rprompt: false,
+            xonsh_use_right_prompt: false,
         }
     }
 }

--- a/src/shell/detect.rs
+++ b/src/shell/detect.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Context, Result};
 pub enum ShellKind {
     Bash,
     Fish,
+    Xonsh,
     Zsh,
 }
 
@@ -15,6 +16,7 @@ impl ShellKind {
         Some(match name {
             "bash" | "dash" => ShellKind::Bash,
             "fish" => ShellKind::Fish,
+            "xonsh" | "python" => ShellKind::Xonsh,
             "zsh" => ShellKind::Zsh,
             _ => return None,
         })
@@ -55,7 +57,7 @@ fn parse_command(cmd: &str) -> &str {
     let binary_path = &cmd[..first_space];
     let last_path_sep = binary_path.rfind("/").map(|x| x + 1).unwrap_or(0);
     let binary = &binary_path[last_path_sep..];
-    binary.trim_start_matches("-")
+    binary.trim_start_matches("-").trim_end_matches(|c: char| c.is_digit(10) || c == '.')
 }
 
 /// Detect from which kind of shell kubie was spawned.
@@ -110,4 +112,9 @@ fn test_parse_command_with_path_and_args() {
 #[test]
 fn test_parse_command_login_shell() {
     assert_eq!(parse_command("-zsh"), "zsh");
+}
+
+#[test]
+fn test_parse_command_versioned_intepreter() {
+    assert_eq!(parse_command("python3.8"), "python");
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -16,6 +16,7 @@ mod bash;
 mod detect;
 mod fish;
 mod prompt;
+mod xonsh;
 mod zsh;
 
 pub struct EnvVars<'n> {
@@ -87,6 +88,10 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
         "KUBIE_FISH_USE_RPROMPT",
         if settings.prompt.fish_use_rprompt { "1" } else { "0" },
     );
+    env_vars.insert(
+        "KUBIE_XONSH_USE_RIGHT_PROMPT",
+        if settings.prompt.xonsh_use_right_prompt { "1" } else { "0" },
+    );
 
     match kind {
         ShellKind::Bash => {
@@ -94,6 +99,9 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
         }
         ShellKind::Fish => {
             env_vars.insert("KUBIE_SHELL", "fish");
+        }
+        ShellKind::Xonsh => {
+            env_vars.insert("KUBIE_SHELL", "xonsh");
         }
         ShellKind::Zsh => {
             env_vars.insert("KUBIE_SHELL", "zsh");
@@ -109,6 +117,7 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
     match kind {
         ShellKind::Bash => bash::spawn_shell(&info),
         ShellKind::Fish => fish::spawn_shell(&info),
+        ShellKind::Xonsh => xonsh::spawn_shell(&info),
         ShellKind::Zsh => zsh::spawn_shell(&info),
     }
 }

--- a/src/shell/prompt.rs
+++ b/src/shell/prompt.rs
@@ -52,18 +52,24 @@ where
         E: Display,
     {
         match self.shell_kind {
-            ShellKind::Fish => write!(f, "{}", content),
+            ShellKind::Fish | ShellKind::Xonsh => write!(f, "{}", content),
             ShellKind::Zsh => write!(f, "%{{{}%}}", content),
             _ => write!(f, "\\[{}\\]", content),
         }
     }
 
     fn start_color(&self, f: &mut fmt::Formatter, color: u32) -> fmt::Result {
-        self.isolate(f, format!("\\e[{}m", color))
+        match self.shell_kind {
+            ShellKind::Xonsh => self.isolate(f, format!("\\033[{}m", color)),
+            _ => self.isolate(f, format!("\\e[{}m", color))
+        }
     }
 
     fn end_color(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.isolate(f, "\\e[0m")
+        match self.shell_kind {
+            ShellKind::Xonsh => self.isolate(f, "\\033[0m"),
+            _ => self.isolate(f, "\\e[0m")
+        }
     }
 }
 

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -15,6 +15,20 @@ pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
     write!(
         temp_rc_file_buf,
         r#"
+# https://xon.sh/xonshrc.html
+from pathlib import Path
+
+files = [
+    "/etc/xonshrc",
+    "~/.xonshrc",
+    "~/.config/xonsh/rc.xsh",
+]
+for file in files:
+    if Path(file).is_file():
+        source @(file)
+if Path("~/.config/xonsh/rc.d").is_dir():
+    for file in path.glob('*.xsh'):
+        source @(file)
 "#
     )?;
 

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -47,7 +47,7 @@ import re
 for match in re.finditer(r'\$\(([^)]*)\)', $KUBIE_PROMPT):
     command = match.group(1)
     name = command.split(' ')[-1]
-    $PROMPT_FIELDS[name] = $(@(command.split(' '))).strip()
+    $PROMPT_FIELDS[name] = evalx(f'lambda: $({{command}}).strip()')
     $KUBIE_PROMPT = $KUBIE_PROMPT.replace(f'$({{command}})', '{{' + name + '}}')
 
 if $KUBIE_XONSH_USE_RIGHT_PROMPT == "1":

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -1,0 +1,57 @@
+use std::io::{BufWriter, Write};
+use std::process::Command;
+
+use anyhow::Result;
+
+use super::ShellSpawnInfo;
+
+pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
+    let temp_rc_file = tempfile::Builder::new()
+        .prefix("kubie-xonshrc")
+        .suffix(".xonsh")
+        .tempfile()?;
+    let mut temp_rc_file_buf = BufWriter::new(temp_rc_file.as_file());
+
+    write!(
+        temp_rc_file_buf,
+        r#"
+"#
+    )?;
+
+    if !info.settings.prompt.disable {
+        write!(
+            temp_rc_file_buf,
+            r#"
+$KUBIE_PROMPT='{}'
+import re
+
+# Fanciful prompt-command replacement as xonsh forces the use of PROMPT_FIELDS
+for match in re.finditer(r'\$\(([^)]*)\)', $KUBIE_PROMPT):
+    command = match.group(1)
+    name = command.split(' ')[-1]
+    $PROMPT_FIELDS[name] = $(@(command.split(' '))).strip()
+    $KUBIE_PROMPT = $KUBIE_PROMPT.replace(f'$({{command}})', '{{' + name + '}}')
+
+if $KUBIE_XONSH_USE_RIGHT_PROMPT == "1":
+    $RIGHT_PROMPT = $KUBIE_PROMPT + $RIGHT_PROMPT
+else:
+    $PROMPT = $KUBIE_PROMPT + $PROMPT
+
+del $KUBIE_PROMPT
+"#,
+            info.prompt,
+        )?;
+    }
+
+    temp_rc_file_buf.flush()?;
+
+    let mut cmd = Command::new("xonsh");
+    cmd.arg("--rc");
+    cmd.arg(temp_rc_file.path());
+    info.env_vars.apply(&mut cmd);
+
+    let mut child = cmd.spawn()?;
+    child.wait()?;
+
+    Ok(())
+}

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -29,6 +29,10 @@ for file in files:
 if Path("~/.config/xonsh/rc.d").is_dir():
     for file in path.glob('*.xsh'):
         source @(file)
+
+@events.on_precommand
+def __kubie_cmd_pre_exec__(cmd):
+    $KUBECONFIG = $KUBIE_KUBECONFIG
 "#
     )?;
 

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -8,7 +8,7 @@ use super::ShellSpawnInfo;
 pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
     let temp_rc_file = tempfile::Builder::new()
         .prefix("kubie-xonshrc")
-        .suffix(".xonsh")
+        .suffix(".xsh")
         .tempfile()?;
     let mut temp_rc_file_buf = BufWriter::new(temp_rc_file.as_file());
 
@@ -46,7 +46,7 @@ import re
 # Fanciful prompt-command replacement as xonsh forces the use of PROMPT_FIELDS
 for match in re.finditer(r'\$\(([^)]*)\)', $KUBIE_PROMPT):
     command = match.group(1)
-    name = command.split(' ')[-1]
+    name = command.split().pop()
     $PROMPT_FIELDS[name] = evalx(f'lambda: $({{command}}).strip()')
     $KUBIE_PROMPT = $KUBIE_PROMPT.replace(f'$({{command}})', '{{' + name + '}}')
 


### PR DESCRIPTION
Mostly straightforward changes; not a xonsh or rust expert but it works on my machine :smile: a few notes to help explain why I did things the way I did:
 - xonsh doesn't like the `\e` color escapes (but works fine with `\033`)
 - xonsh runs in a python subprocess
 - xonsh doesn't let users embed arbitrary commands into the prompt without first adding them to the `PROMPT_FIELDS` dict.