### PR TITLE
Update README.md about installing kubie on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You can also install `kubie` from [MacPorts](https://www.macports.org) by runnin
 ### Nix
 There is a `kubie` Nix package maintained by @illiusdope that you can install.
 
+### Arch Linux
+`kubie` is available in the [community repository](https://archlinux.org/packages/community/x86_64/kubie/) and it can be installed by running `pacman -S kubie`.
+
 ### Autocompletion
 
 #### Bash


### PR DESCRIPTION
Hello!

I started maintaining `kubie` in the Arch Linux community repository: https://archlinux.org/packages/community/x86_64/kubie/

The reason why I'm submitting this PR is that now Arch Linux users can install `kubie` via `pacman` and I thought README.md should mention that.

Thank you! :bear:
