### PR TITLE
fix bug where fish completion for contexts would not terminate

### DIFF
--- a/completion/kubie.fish
+++ b/completion/kubie.fish
@@ -15,7 +15,7 @@ complete -c kubie -n "$cmd help" -a "$commands"
 
 # FIXME: This should take --kubeconfig into account
 complete -c kubie -n "$cmd ctx delete edit exec; and __kubie_at_arg 1" -d 'context' \
-    -a '(kubie ctx 2>/dev/null)'
+    -a '(kubectl config get-contexts -o name)'
 
 complete -c kubie -n "$cmd ctx ns" -l recursive -s r -d 'spawn a new recursive shell'
 


### PR DESCRIPTION
`kubie ctx` does not list contexts, it spawns a kubie shell which in turn will prevent the dynamic completion generation from terminating. This PR fixes that oversight by using kubectl itself to generate the list of contexts.