### PR TITLE
Add support for pre/post shell hooks to bash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ behavior:
     #   never:  Never prints context headers.
     # Default: auto
     print_context_in_exec: auto
+
+# Optional start and stop hooks
+hooks:
+    # A command hook to run when a CTX is started.  
+    # This example re-labels your terminal window
+    # Default: none
+    start_ctx: >
+        echo -en "\033]1; `kubie info ctx`|`kubie info ns` \007"
+
+    # A command hook to run when a CTX is stopped
+    # This example sets the terminal back to the shell name
+    # Default: none
+    stop_ctx: >
+        echo -en "\033]1; $SHELL \007"
+
 ```
 
 ## For distro maintainers

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -39,6 +39,8 @@ pub struct Settings {
     pub prompt: Prompt,
     #[serde(default)]
     pub behavior: Behavior,
+    #[serde(default)]
+    pub hooks: Hooks,
 }
 
 impl Settings {
@@ -181,6 +183,23 @@ impl Default for Behavior {
         Behavior {
             validate_namespaces: true,
             print_context_in_exec: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Hooks {
+    #[serde(default)]
+    pub start_ctx: String,
+    #[serde(default)]
+    pub stop_ctx: String,
+}
+
+impl Default for Hooks {
+    fn default() -> Self {
+        Hooks {
+            start_ctx: format!(""),
+            stop_ctx: format!(""),
         }
     }
 }

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -66,6 +66,14 @@ unset KUBIE_PROMPT
         )?;
     }
 
+	if info.settings.hooks.start_ctx != "" {
+		write!(
+			temp_rc_file_buf,
+			"{}", 
+            info.settings.hooks.start_ctx
+		)?;
+	}
+
     temp_rc_file_buf.flush()?;
 
     let mut cmd = Command::new("bash");
@@ -75,6 +83,26 @@ unset KUBIE_PROMPT
 
     let mut child = cmd.spawn()?;
     child.wait()?;
+    
+	if info.settings.hooks.start_ctx != "" {
+		let temp_exit_hook_file = tempfile::Builder::new()
+			.prefix("kubie-bash-exit-hook")
+			.suffix(".bash")
+			.tempfile()?;
+		let mut temp_exit_hook_file_buf = BufWriter::new(temp_exit_hook_file.as_file());
+
+		write!(
+			temp_exit_hook_file_buf,
+			  "{}", info.settings.hooks.stop_ctx)?;
+
+		temp_exit_hook_file_buf.flush()?;
+		let mut exit_cmd = Command::new("bash");
+		exit_cmd.arg(temp_exit_hook_file.path());
+		info.env_vars.apply(&mut exit_cmd);
+
+        let mut child = exit_cmd.spawn()?;
+        child.wait()?;
+	}
 
     Ok(())
 }


### PR DESCRIPTION
I found it desirable to add pre/post shell hooks to starting a session.  I use it to update my `tmux` session when I start a `kubie` session.  Just sending along in case anyone else might find it useful!