### PR TITLE
feat: add export feature

### DIFF
--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,0 +1,25 @@
+use anyhow::{anyhow, Result};
+
+use crate::kubeconfig::{self, KubeConfig};
+use crate::settings::{ContextHeaderBehavior, Settings};
+
+pub fn export(settings: &Settings, context_name: String, namespace_name: String, args: Vec<String>) -> Result<()> {
+    let installed = kubeconfig::get_installed_contexts(settings)?;
+    let matching = installed.get_contexts_matching(&context_name);
+
+    if matching.is_empty() {
+        return Err(anyhow!("No context matching {}", context_name));
+    }
+
+    for context_src in matching {
+        let kubeconfig = installed.make_kubeconfig_for_context(&context_src.item.name, Some(&namespace_name))?;
+        let temp_config_file = tempfile::Builder::new()
+            .prefix("kubie-config")
+            .suffix(".yaml")
+            .tempfile()?;
+        kubeconfig.write_to(&temp_config_file)?;
+        println!("{}", temp_config_file.path().display());
+    }
+
+    std::process::exit(0);
+}

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use crate::kubeconfig::{self, KubeConfig};
 use crate::settings::{ContextHeaderBehavior, Settings};
 
-pub fn export(settings: &Settings, context_name: String, namespace_name: String, args: Vec<String>) -> Result<()> {
+pub fn export(settings: &Settings, context_name: String, namespace_name: String) -> Result<()> {
     let installed = kubeconfig::get_installed_contexts(settings)?;
     let matching = installed.get_contexts_matching(&context_name);
 

--- a/src/cmd/meta.rs
+++ b/src/cmd/meta.rs
@@ -69,8 +69,6 @@ pub enum Kubie {
         context_name: String,
         /// Namespace in which to run the command. This is mandatory to avoid potential errors.
         namespace_name: String,
-        /// Command to run as well as its arguments.
-        args: Vec<String>,
     },
 
     /// Check the Kubernetes config files for issues.

--- a/src/cmd/meta.rs
+++ b/src/cmd/meta.rs
@@ -63,6 +63,16 @@ pub enum Kubie {
         args: Vec<String>,
     },
 
+    #[clap(name = "export", trailing_var_arg = true)]
+    Export {
+        /// Name of the context in which to run the command.
+        context_name: String,
+        /// Namespace in which to run the command. This is mandatory to avoid potential errors.
+        namespace_name: String,
+        /// Command to run as well as its arguments.
+        args: Vec<String>,
+    },
+
     /// Check the Kubernetes config files for issues.
     #[clap(name = "lint")]
     Lint,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -11,6 +11,7 @@ pub mod context;
 pub mod delete;
 pub mod edit;
 pub mod exec;
+pub mod export;
 pub mod info;
 pub mod lint;
 pub mod meta;

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,13 @@ fn main() -> Result<()> {
         Kubie::Delete { context_name } => {
             cmd::delete::delete_context(&settings, &skim_options, context_name)?;
         }
+        Kubie::Export {
+            context_name,
+            namespace_name,
+            args,
+        } => {
+            cmd::export::export(&settings, context_name, namespace_name, args)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
I'm a heavy direnv user, I really like that when I cd into a folder it automatically sets up the developer environment for me. 

One thing I can't do yet is switch kube contexts based on which directory I'm in. I noticed there is kubie exec, which is pretty close to what I want, except I also want it to be declarative so I basically copied exec, except I don't delete the created kubeconfig file.

This PR is a little messy, but I figured I'd open it to see if this was a reasonable feature before I put more time into it. 

The intended use case is to create a .envrc file like
```
NAMESPACE=${NAMESPACE:-default}
CONTEXT="my-cluster"
export KUBECONFIG=$(kubie export $CONTEXT $NAMESPACE) 
```