### PR TITLE
Use XDG base dir spec for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Selectable menus will be available when using `kubie ctx` and `kubie ns`.
 * `kubie update` will check the latest kubie version and update your local installation if needed
 
 ## Settings
-You can customize kubie's behavior with the `~/.kube/kubie.yaml` file. The settings available and their defaults are
+You can customize kubie's behavior with the `~/.config/kubie/config.yaml` file. The settings available and their defaults are
 available below.
 
 ```yaml
@@ -165,7 +165,7 @@ behavior:
 
 # Optional start and stop hooks
 hooks:
-    # A command hook to run when a CTX is started.  
+    # A command hook to run when a CTX is started.
     # This example re-labels your terminal window
     # Default: none
     start_ctx: >

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -81,7 +81,8 @@ impl Settings {
             Settings::default()
         };
 
-        // Very important to exclude kubie's own config file ~/.kube/kubie.yaml from the results.
+        // Very important to exclude kubie's own config file from the results
+        // it is ~/.config/kubie/config.yaml by default
         settings.configs.exclude.push(settings_path_str);
         Ok(settings)
     }


### PR DESCRIPTION
The [XDG base directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) specification is a popular way to store config files that doesn't clutter a user's home directory with [dotfiles](https://utf9k.net/questions/linux-why-do-dotfiles-exist/).

This tool stores its configuration in `~/.kube/kubie.yaml`, however, I think it should follow the spec and store it in a location that is not shared by other tools.

Fortunately, the `dirs` crate has [native support](https://docs.rs/dirs/5.0.1/dirs/fn.config_dir.html) for the XDG base directory spec, so we can use it to handle resolving the environment variables and falling back to the defaults in the spec.

What this means is that the new default location for this tool's settings from this PR onwards is `~/.config/kubie/config.yaml`. If the old config file exists, it will prefer that. Otherwise, it will create the parent directories for the XDG based config file.