### PR TITLE
Revert commit 4097062

### DIFF
--- a/completion/kubie.fish
+++ b/completion/kubie.fish
@@ -15,7 +15,7 @@ complete -c kubie -n "$cmd help" -a "$commands"
 
 # FIXME: This should take --kubeconfig into account
 complete -c kubie -n "$cmd ctx delete edit exec; and __kubie_at_arg 1" -d 'context' \
-    -a '(kubectl config get-contexts -o name)'
+    -a '(kubie ctx 2> /dev/null)'
 
 complete -c kubie -n "$cmd ctx ns" -l recursive -s r -d 'spawn a new recursive shell'
 


### PR DESCRIPTION
This commit breaks tab completion for contexts outside the KUBECONFIG file. This fixes #160 