### PR TITLE
Copy ZDOTDIR if configured

### DIFF
--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -26,13 +26,14 @@ elif [[ -f "/etc/zsh/zshenv" ]] ; then
 fi
 
 if [[ -f "$HOME/.zshenv" ]] ; then
-    tmp_ZDOTDIR=$ZDOTDIR
+    tmp_ZDOTDIR="$ZDOTDIR"
     source "$HOME/.zshenv"
-    # If the user has overridden $ZDOTDIR, we save that in $_KUBIE_USER_ZDOTDIR for later reference
-    # and reset $ZDOTDIR
+    # If the user has overridden $ZDOTDIR, we save that in $_KUBIE_USER_ZDOTDIR for later reference,
+    # copy its contents and reset $ZDOTDIR
     if [[ "$tmp_ZDOTDIR" != "$ZDOTDIR" ]]; then
-        _KUBIE_USER_ZDOTDIR=$ZDOTDIR
-        ZDOTDIR=$tmp_ZDOTDIR
+        _KUBIE_USER_ZDOTDIR="$ZDOTDIR"
+        cp -r "$ZDOTDIR/." "$tmp_ZDOTDIR"
+        ZDOTDIR="$tmp_ZDOTDIR"
         unset tmp_ZDOTDIR
     fi
 fi


### PR DESCRIPTION
Dependent files can be present in `ZDOTDIR` if the user has configured it. This PR simply copies its contents.

I realise this is not an optimal solution; if you have a lot of plugins in `ZDOTDIR`, copying it in its entirety may bring considerable overhead.

However, it does effectively solve the reported problem.

This fixes #132

Feedback more than welcome! 🙂