### PR TITLE
Automatically configure HISTFILE to preserve history

### DIFF
--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -37,9 +37,14 @@ if [[ -f "$HOME/.zshenv" ]] ; then
     fi
 fi
 
-# If a zsh_history file exists, copy it over before zsh initialization so history is maintained
-if [[ -f "$HOME/.zsh_history" ]] ; then
-    cp $HOME/.zsh_history $ZDOTDIR
+# Configure HISTFILE to an existing .zsh_history unless already configured to preserve history.
+if [[ -f "$HISTFILE" ]] ; then
+    # We are using the user's configured history file.
+    :
+elif [[ -f "$_KUBIE_USER_ZDOTDIR/.zsh_history" ]] ; then
+    export HISTFILE="$_KUBIE_USER_ZDOTDIR/.zsh_history"
+elif [[ -f "$HOME/.zsh_history" ]] ; then
+    export HISTFILE="$HOME/.zsh_history"
 fi
 
 KUBIE_LOGIN_SHELL=0


### PR DESCRIPTION
The best fix is to explicitly configure `HISTFILE`. However (understandably) many users don't have this or know about this. This PR automatically configures `HISTFILE` to point to the original `.zsh_history` of the user instead of in the created `tmp` directory.

In lieu or accompanied with this, perhaps we can document the recommendation of setting `HISTFILE`?

I realise now I included #81 in my commit message but this fix only applies for zsh, not other shells.