### PR TITLE
document export subcomannd

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Selectable menus will be available when using `kubie ctx` and `kubie ns`.
   in the given namespace
 * `kubie exec <wildcard> <namespace> -e <cmd> <args>...` execute a command in all the contexts matched by the wildcard and
   in the given namespace but fail early if any of the commands executed return a non-zero exit code
+* `kubie export <context> <namespace>` prints the path to an isolated config file for a context and namespace
 * `kubie edit` display a selectable menu of contexts to edit
 * `kubie edit <context>` edit the file that contains this context
 * `kubie edit-config` edit kubie's own config file

--- a/src/cmd/meta.rs
+++ b/src/cmd/meta.rs
@@ -63,11 +63,12 @@ pub enum Kubie {
         args: Vec<String>,
     },
 
+    /// Prints the path to an isolated configuration file for a context and namespace.
     #[clap(name = "export")]
     Export {
-        /// Name of the context in which to run the command.
+        /// Name of the context to export.
         context_name: String,
-        /// Namespace in which to run the command. This is mandatory to avoid potential errors.
+        /// Name of the namespace in the context. This is mandatory to avoid potential errors.
         namespace_name: String,
     },
 


### PR DESCRIPTION
The `export` subcommand was added in #125, but was not documented with clap or in the project readme. As a result, it's not clear kubie can be used alongside other tools such as direnv.

This changeset adds the docstrings for clap, rephrases the documentation for the arguments, and includes it in the list of subcommands in the project readme.