### PR TITLE
add basic support for Elvish

### DIFF
--- a/src/shell/detect.rs
+++ b/src/shell/detect.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Context, Result};
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ShellKind {
     Bash,
+    Elvish,
     Fish,
     Xonsh,
     Zsh,
@@ -16,6 +17,7 @@ impl ShellKind {
     pub fn from_str(name: &str) -> Option<ShellKind> {
         Some(match name {
             "bash" | "dash" => ShellKind::Bash,
+            "elvish" => ShellKind::Elvish,
             "fish" => ShellKind::Fish,
             "xonsh" | "python" => ShellKind::Xonsh,
             "zsh" => ShellKind::Zsh,

--- a/src/shell/elvish.rs
+++ b/src/shell/elvish.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use std::process::Command;
+
+use crate::shell::ShellSpawnInfo;
+
+pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
+    let mut cmd = Command::new("elvish");
+    info.env_vars.apply(&mut cmd);
+    let _ = cmd.status()?;
+    Ok(())
+}

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -13,6 +13,7 @@ use crate::vars;
 
 mod bash;
 mod detect;
+mod elvish;
 mod fish;
 mod nu;
 mod prompt;
@@ -100,6 +101,9 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
         ShellKind::Bash => {
             env_vars.insert("KUBIE_SHELL", "bash");
         }
+        ShellKind::Elvish => {
+            env_vars.insert("KUBIE_SHELL", "elvish");
+        }
         ShellKind::Fish => {
             env_vars.insert("KUBIE_SHELL", "fish");
         }
@@ -122,6 +126,7 @@ pub fn spawn_shell(settings: &Settings, config: KubeConfig, session: &Session) -
 
     match kind {
         ShellKind::Bash => bash::spawn_shell(&info),
+        ShellKind::Elvish => elvish::spawn_shell(&info),
         ShellKind::Fish => fish::spawn_shell(&info),
         ShellKind::Xonsh => xonsh::spawn_shell(&info),
         ShellKind::Zsh => zsh::spawn_shell(&info),


### PR DESCRIPTION
Elvish's syntax is not compatible with other POSIX shells, the prompt is generated more dynamically. For now I think it's better to leave it to the users to decide what to put inside the prompt.