### PR TITLE
order contexts alphabetically in kubie exec

### DIFF
--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -58,7 +58,8 @@ pub fn exec(
     }
 
     let installed = kubeconfig::get_installed_contexts(settings)?;
-    let matching = installed.get_contexts_matching(&context_name);
+    let mut matching = installed.get_contexts_matching(&context_name);
+    matching.sort_by(|a, b| a.item.name.cmp(&b.item.name));
 
     if matching.is_empty() {
         return Err(anyhow!("No context matching {}", context_name));


### PR DESCRIPTION
When running `kubie exec` on multiple contexts using a wildcard, the context ordering may vary between executions.  This PR sorts the contexts by name so that the ordering is consistent, which is nice to have when eyeballing the results of consecutive runs.

