### PR TITLE
Use $XONSHRC environment variable to ascertain files

### DIFF
--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -18,11 +18,8 @@ pub fn spawn_shell(info: &ShellSpawnInfo) -> Result<()> {
 # https://xon.sh/xonshrc.html
 from pathlib import Path
 
-files = [
-    "/etc/xonshrc",
-    "~/.xonshrc",
-    "~/.config/xonsh/rc.xsh",
-]
+files = $XONSHRC
+
 for file in files:
     if Path(file).is_file():
         source @(file)


### PR DESCRIPTION
Because the assumption that those hard-coded paths are the only paths a user may have feels wrong.

Also, Because pathlib.Path wasn't resolving ~ to a proper absolute path.

```
♄ 19:46:51 rrs@priyasi ~  [1]                                                                                                                                      ☸ cs00114-we-01-aks
@ from pathlib import Path
♒︎ 19:46:56 rrs@priyasi ~                                                                                                                                          ☸ cs00114-we-01-ak s
@ Path("~/.xonshrc")
PosixPath('~/.xonshrc')
⛢ 19:47:16 rrs@priyasi ~                                                                                                                                           ☸ cs00114-we-01-aks
@ Path("~/.xonshrc").is_file()
False
♅ 19:47:22 rrs@priyasi ~                                                                                                                                           ☸ cs00114-we-01-aks
@ Path("/home/rrs/.xonshrc").is_file()
True
ॐ 19:47:30 rrs@priyasi ~                                                                                                                                           ☸ cs00114-we-01-aks
@ $XONSHRC
('/etc/xonsh/xonshrc', '/home/rrs/.config/xonsh/rc.xsh', '/home/rrs/.xonshrc')
⛢ 19:48:21 rrs@priyasi ~                                                                                                                                           ☸ cs00114-we-01-aks
@ for file in $XONSHRC:
.     print(file)
.
/etc/xonsh/xonshrc
/home/rrs/.config/xonsh/rc.xsh
/home/rrs/.xonshrc
````