### PR TITLE
fix: default value in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ prompt:
     # Disable kubie's custom prompt inside of a kubie shell. This is useful
     # when you already have a prompt displaying kubernetes information.
     # Default: false
-    disable: true
+    disable: false
 
     # When using recursive contexts, show depth when larger than 1.
     # Default: true


### PR DESCRIPTION
I have noticed, that all comments reflects the actual data, but not in the case of `disable`.