### PR TITLE
fix: remove superfluous bash prompt characters

### DIFF
--- a/src/shell/prompt.rs
+++ b/src/shell/prompt.rs
@@ -55,7 +55,8 @@ where
         match self.shell_kind {
             ShellKind::Fish | ShellKind::Xonsh => write!(f, "{content}"),
             ShellKind::Zsh => write!(f, "%{{{content}%}}"),
-            _ => write!(f, "\\[{content}\\]"),
+            ShellKind::Bash => write!(f, "\\[{content}\\]"),
+            _ => write!(f, "{content}"),
         }
     }
 


### PR DESCRIPTION
Those escaped brackets are visible in my prompt, and they break arrow-key commandline editing