### PR TITLE
fix: don't reset namespace when running ctx in interactive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Zlib"
 name = "kubie"
 readme = "README.md"
 repository = "https://github.com/sbstp/kubie"
-version = "0.25.1"
+version = "0.25.2"
 
 [dependencies]
 anyhow = "1"

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -74,10 +74,7 @@ pub fn context(
     let context_name = match context_name {
         Some(context_name) => context_name,
         None => match select_or_list_context(skim_options, &mut installed)? {
-            SelectResult::Selected(x) => {
-                namespace_name = None;
-                x
-            }
+            SelectResult::Selected(x) => x,
             _ => return Ok(()),
         },
     };


### PR DESCRIPTION
This PR propose a fix to avoid resetting the `namespace_name` if we select the context when running the following command:

```
kubie ctx -n my-namespace
```

Actually, `-n` flag is interpreted only when you precise the context directly, like :

```
kubiectx -n my-namespace my-context
```