### PR TITLE
feat: skim options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,38 @@ mod state;
 mod vars;
 
 fn main() -> Result<()> {
-    let settings = Settings::load()?;
-    let skim_options = SkimOptionsBuilder::default().multi(false).build().unwrap();
+    let mut settings = Settings::load()?;
+
+    let skim_options = {
+        let mut options = SkimOptionsBuilder::default();
+
+        options.no_multi(true);
+
+        options.color(settings.fzf.color.take());
+
+        if settings.fzf.ignore_case {
+            options.case(skim::CaseMatching::Ignore);
+        };
+
+        if !settings.fzf.mouse {
+            options.no_mouse(true);
+        };
+
+        if settings.fzf.reverse {
+            options.reverse(true);
+        }
+
+        if settings.fzf.info_hidden {
+            options.no_info(true);
+        }
+
+        if let Some(prompt) = settings.fzf.prompt.take() {
+            options.prompt(prompt);
+        }
+
+        options.build().unwrap()
+    };
+
     let kubie = Kubie::parse();
 
     match kubie {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,6 +29,16 @@ pub fn expanduser(path: &str) -> String {
     }
 }
 
+#[derive(Default, Debug, Deserialize)]
+pub struct Fzf {
+    pub mouse: bool,
+    pub reverse: bool,
+    pub ignore_case: bool,
+    pub info_hidden: bool,
+    pub prompt: Option<String>,
+    pub color: Option<String>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 pub struct Settings {
     #[serde(default)]
@@ -43,6 +53,8 @@ pub struct Settings {
     pub behavior: Behavior,
     #[serde(default)]
     pub hooks: Hooks,
+    #[serde(default)]
+    pub fzf: Fzf,
 }
 
 impl Settings {


### PR DESCRIPTION
Skim tries to copy fzf options, but with a very strange public API and no backwards compatibility, so I've added the most useful (in my opinion) options that are similar to fzf so anyone can copy-paste them from fzf config to kubie. 

Also Skim currently has a lot of options reserved for the future, which may be added here.

New options in kubie.yaml:

```yaml
fzf:
  mouse: false
  reverse: true
  ignore_case: true
  info_hidden: true
  prompt: '󰅂 '
  color: >
    g:-1,border:-1,current_bg:-1,
    current_fg:7,current_hl:7,fg:8,
    gutter:-1,header:8,hl:8,info:8,
    marker:7,pointer:7,prompt:7,
    spinner:7
```

Compared to default:

![image](https://github.com/user-attachments/assets/fe1afd29-0191-490e-a3b0-c4315012dacc)
