### PR TITLE
add option to allow multiple context patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ behavior:
     # Default: auto
     print_context_in_exec: auto
 
+    # Parse the CONTEXT_NAME argument to `kubie exec` and `kubie export` as a
+    # space-delimited list, allowing multiple patterns to be specified.
+    # Example:
+    #   kubie exec 'dev-* pre-* staging-1 prod-2' kube-system -- kubectl get po
+    # Default: false
+    allow_multiple_context_patterns: false
+
 # Optional start and stop hooks
 hooks:
     # A command hook to run when a CTX is started.  

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -58,8 +58,7 @@ pub fn exec(
     }
 
     let installed = kubeconfig::get_installed_contexts(settings)?;
-    let mut matching = installed.get_contexts_matching(&context_name);
-    matching.sort_by(|a, b| a.item.name.cmp(&b.item.name));
+    let matching = installed.get_contexts_matching(&context_name, settings.behavior.allow_multiple_context_patterns);
 
     if matching.is_empty() {
         return Err(anyhow!("No context matching {}", context_name));

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -5,7 +5,7 @@ use crate::settings::Settings;
 
 pub fn export(settings: &Settings, context_name: String, namespace_name: String) -> Result<()> {
     let installed = kubeconfig::get_installed_contexts(settings)?;
-    let matching = installed.get_contexts_matching(&context_name);
+    let matching = installed.get_contexts_matching(&context_name, settings.behavior.allow_multiple_context_patterns);
 
     if matching.is_empty() {
         return Err(anyhow!("No context matching {}", context_name));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -186,6 +186,8 @@ pub struct Behavior {
     pub validate_namespaces: ValidateNamespacesBehavior,
     #[serde(default)]
     pub print_context_in_exec: ContextHeaderBehavior,
+    #[serde(default = "def_bool_false")]
+    pub allow_multiple_context_patterns: bool,
 }
 
 #[derive(Debug, Deserialize, Default)]


### PR DESCRIPTION
Adds a new behavior setting `allow_multiple_context_patterns` which parses the context-name argument as a space-delimited list, allowing multiple patterns to be specified in calls to `kubie exec` and `kubie export`.  Useful in cases where you want to target multiple disparate clusters in one shot, i.e.:

```
kubie exec 'dev-* pre-* staging-1 prod-2' kube-system -- kubectl get po
```

The new setting defaults to `false`, which preserves the original functionality.