### PR TITLE
add generate-completion command using clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.56"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd"
+checksum = "39615915e2ece2550c0149addac32fb5bd312c657f43845bb9088cb9c8a7c992"
 dependencies = [
  "clap",
 ]
@@ -981,6 +981,7 @@ dependencies = [
  "aws-lc-rs",
  "cfg-if",
  "clap",
+ "clap_complete",
  "dirs",
  "fs2",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ version = "0.26.0"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5.43", features = ["derive"] }
+clap_complete = "4.5.61"
 cfg-if = "1"
 dirs = "6"
 fs2 = "0.4"

--- a/README.md
+++ b/README.md
@@ -38,31 +38,22 @@ You can also install `kubie` from [MacPorts](https://www.macports.org) by runnin
 There is a `kubie` Nix package maintained by @illiusdope that you can install.
 
 ### Arch Linux
-`kubie` is available in the [extra repository](https://archlinux.org/packages/extra/x86_64/kubie/) and it can be installed by running `pacman -S kubie`.
+`kubie` is available in the [extra repository](https://archlinux.org/packages/extra/x86_64/kubie/), and it can be installed by running `pacman -S kubie`.
 
 ### Autocompletion
 
-#### Bash
+Autocompletion can be enabled by adding one of the following lines to your shell's configuration file, e.g., `~/.bashrc`
+or `~/.zshrc`:
 
-If you want autocompletion for `kubie ctx`, `kubie ns` and `kubie exec`, please install this script:
-```bash
-sudo cp ./completion/kubie.bash /etc/bash_completion.d/kubie
+```sh
+# Bash / Zsh / others
+source <(kubie generate-completion)
+# Fish
+kubie generate-completion fish | source
 ```
 
-Then spawn new shell or source copied file:
-```bash
-. /etc/bash_completion.d/kubie
-```
-
-#### Fish
-
-Install the completions script [kubie.fish](completion/kubie.fish) by copying it, eg.:
-
-```bash
-cp completion/kubie.fish ~/.config/fish/completions/
-```
-
-Then reopen fish or source the file.
+See the [clap-complete docs](https://docs.rs/clap_complete/latest/clap_complete/aot/enum.Shell.html) for all supported
+shells.
 
 ## Usage
 Selectable menus will be available when using `kubie ctx` and `kubie ns`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,9 @@ fn main() -> Result<()> {
         } => {
             cmd::export::export(&settings, context_name, namespace_name)?;
         }
+        Kubie::GenerateCompletion(cmd) => {
+            cmd::meta::generate_completion(cmd);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Built this for myself, figured I'd contribute it upstream. 

Supports multiple shells, as the Readme suggests see https://docs.rs/clap_complete/latest/clap_complete/aot/enum.Shell.html for a list of supported shells, but it'll try to figure it out if you don't tell it.

Doesn't add completion for your contexts, but when combined with `fzf` it's nice enough to `kubie ctx` and select your desired context.