### PR TITLE
feat: restore last used ctx and ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Selectable menus will be available when using `kubie ctx` and `kubie ns`.
 
 * `kubie ctx` display a selectable menu of contexts
 * `kubie ctx <context>` switch the current shell to the given context (spawns a shell if not a kubie shell)
-* `kubie ctx -` switch back to the previous context
+* `kubie ctx -` switch back to the previous context (session history inside a kubie shell, last globally-used context otherwise)
 * `kubie ctx <context> -r` spawn a recursive shell in the given context
 * `kubie ctx <context> -n <namespace>` spawn a shell in the given context and namespace
 * `kubie ns` display a selectable menu of namespaces

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use skim::SkimOptions;
 
 use crate::cmd::{select_or_list_context, SelectResult};
@@ -20,22 +20,27 @@ fn enter_context(
     let state = State::load()?;
     let mut session = Session::load()?;
 
-    let namespace_name =
-        namespace_name.or_else(|| state.namespace_history.get(context_name).and_then(|s| s.as_deref()));
-
     let kubeconfig = if context_name == "-" {
-        let previous_ctx = session
-            .get_last_context()
-            .context("There is no previous context to switch to.")?;
-        installed.make_kubeconfig_for_context(&previous_ctx.context, previous_ctx.namespace.as_deref())?
+        if let Some(previous) = session.get_last_context() {
+            // Inside a kubie shell: switch to the previous context from session history
+            let ns = namespace_name.or(previous.namespace.as_deref());
+            installed.make_kubeconfig_for_context(&previous.context, ns)?
+        } else if let Some(ref last) = state.last_context {
+            // Outside a kubie shell: fall back to the last globally-used context
+            let ns = namespace_name.or_else(|| state.namespace_history.get(last).and_then(|s| s.as_deref()));
+            installed.make_kubeconfig_for_context(last, ns)?
+        } else {
+            anyhow::bail!("There is no previous context to switch to.");
+        }
     } else {
-        installed.make_kubeconfig_for_context(context_name, namespace_name)?
+        let ns = namespace_name.or_else(|| state.namespace_history.get(context_name).and_then(|s| s.as_deref()));
+        installed.make_kubeconfig_for_context(context_name, ns)?
     };
 
-    session.add_history_entry(
+    session.record_context_entry(
         &kubeconfig.contexts[0].name,
         kubeconfig.contexts[0].context.namespace.as_deref(),
-    );
+    )?;
 
     if settings.behavior.validate_namespaces.can_list_namespaces() {
         if let Some(namespace_name) = namespace_name {

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::ioutil;
+use crate::state::State;
 use crate::vars;
 
 /// Session contains information which is scoped to a kubie shell.
@@ -42,6 +43,25 @@ impl Session {
         self.history.push(HistoryEntry {
             context: context.into(),
             namespace: namespace.map(Into::into),
+        })
+    }
+
+    pub fn record_context_entry(
+        &mut self,
+        context_name: impl Into<String>,
+        namespace: Option<impl Into<String>>,
+    ) -> Result<()> {
+        let ctx = context_name.into();
+        let ns = namespace.map(Into::into);
+
+        self.add_history_entry(&ctx, ns.as_deref());
+
+        State::modify(|s| {
+            if ns.is_some() {
+                s.namespace_history.insert(ctx.clone(), ns);
+            }
+            s.last_context = Some(ctx);
+            Ok(())
         })
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,6 +38,9 @@ pub mod paths {
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct State {
+    /// The most recently entered context across all sessions.
+    pub last_context: Option<String>,
+
     /// This map stores the last namespace in which a context was used, in order to restore the namespace
     /// when the context is entered again.
     ///


### PR DESCRIPTION
Add support for restoring the last-used context across shell sessions:

Closes: #88

### What's added

- `kubie ctx -` now works from a non-kubie shell by falling back to the last globally-used context persisted in `state.json` cache.
- Every context switch automatically records the context in global state by default
- `kubie ctx - -n <namespace>` now honors the explicit namespace override (previously `-n` arg was silently ignored when combined with `-`)

### How it works

- `kubie ctx <name>` from a regular shell, then `kubie ctx -` from a new shell to enter the same context
- `kubie ctx -` with no prior state gives error: "There is no previous context to switch to."

### Typical usage (in shell init)

```sh
if [[ -o interactive ]] && [[ -z "${KUBIE_ACTIVE}" ]]; then
  kubie ctx - >/dev/null 2>&1
fi
```