### PR TITLE
feat: add more skim customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,38 @@ hooks:
     stop_ctx: >
         echo -en "\033]1; $SHELL \007"
 
+# Customize drop-down skim menu display options.
+# Kubie uses skim as fzf-compatible Rust library for interactive menus.
+fzf:
+    # Enable mouse support in the selectable menu.
+    # Default: true
+    mouse: true
+
+    # Reverse the layout of the menu (show prompt at top).
+    # Default: false
+    reverse: false
+
+    # Enable case-insensitive search.
+    # Default: false
+    ignore_case: false
+
+    # Hide the info line (match count).
+    # Default: false
+    info_hidden: false
+
+    # Set the height of the menu. Can be a percentage (e.g., "50%") or a fixed
+    # number of rows (e.g., "20").
+    # Default: unset (uses full screen)
+    height: "50%"
+
+    # Customize the prompt string.
+    # Default: unset
+    prompt: "> "
+
+    # Set a color scheme. See skim documentation for color format.
+    # See more option in skim docs: https://github.com/skim-rs/skim?tab=readme-ov-file#color-scheme
+    # Default: unset
+    color: "dark"
 ```
 
 ## For distro maintainers

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 
 use cmd::meta::Kubie;
 use settings::Settings;
-use skim::prelude::SkimOptionsBuilder;
 
 mod cmd;
 mod ioutil;
@@ -12,41 +11,14 @@ mod kubectl;
 mod session;
 mod settings;
 mod shell;
+mod skim;
 mod state;
 mod vars;
 
 fn main() -> Result<()> {
-    let mut settings = Settings::load()?;
+    let settings = Settings::load()?;
 
-    let skim_options = {
-        let mut options = SkimOptionsBuilder::default();
-
-        options.no_multi(true);
-
-        options.color(settings.fzf.color.take());
-
-        if settings.fzf.ignore_case {
-            options.case(skim::CaseMatching::Ignore);
-        };
-
-        if !settings.fzf.mouse {
-            options.no_mouse(true);
-        };
-
-        if settings.fzf.reverse {
-            options.reverse(true);
-        }
-
-        if settings.fzf.info_hidden {
-            options.no_info(true);
-        }
-
-        if let Some(prompt) = settings.fzf.prompt.take() {
-            options.prompt(prompt);
-        }
-
-        options.build().unwrap()
-    };
+    let skim_options = skim::build_options(&settings.fzf)?;
 
     let kubie = Kubie::parse();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,11 +31,19 @@ pub fn expanduser(path: &str) -> String {
 
 #[derive(Default, Debug, Deserialize)]
 pub struct Fzf {
+    #[serde(default = "def_bool_true")]
     pub mouse: bool,
+    #[serde(default)]
     pub reverse: bool,
+    #[serde(default)]
     pub ignore_case: bool,
+    #[serde(default)]
     pub info_hidden: bool,
+    #[serde(default)]
+    pub height: Option<String>,
+    #[serde(default)]
     pub prompt: Option<String>,
+    #[serde(default)]
     pub color: Option<String>,
 }
 

--- a/src/skim.rs
+++ b/src/skim.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use skim::prelude::SkimOptionsBuilder;
+
+use crate::settings::Fzf;
+
+pub fn build_options(fzf: &Fzf) -> Result<skim::SkimOptions> {
+    let mut options = SkimOptionsBuilder::default();
+
+    options
+        .no_multi(true)
+        .no_mouse(!fzf.mouse)
+        .reverse(fzf.reverse)
+        .color(fzf.color.clone());
+
+    if fzf.ignore_case {
+        options.case(skim::CaseMatching::Ignore);
+    }
+
+    if fzf.info_hidden {
+        options.no_info(true);
+    }
+
+    if let Some(height) = &fzf.height {
+        options.height(height.clone());
+    }
+
+    if let Some(prompt) = &fzf.prompt {
+        options.prompt(prompt.clone());
+    }
+
+    options
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build skim options: {}", e))
+}


### PR DESCRIPTION
Closes: #348

This pr: 
- brings `height` skim config options
- separates skim initialization logic from main.rs
- makes all fzf settings use serde defaults to prevent parse errors when config fields are missing
- updates README with documentation for all configurable options