### PR TITLE
Sourcing zprofile if ZDOTDIR is set

### DIFF
--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -53,6 +53,10 @@ elif [[ -f "/etc/zsh/zprofile" && "$KUBIE_LOGIN_SHELL" == "1" ]] ; then
     source "/etc/zsh/zprofile"
 fi
 
+if [[ -f "$ZDOTDIR/zprofile"]] ; then
+    source "$ZDOTDIR/zprofile"
+fi
+
 if [[ -f "${{_KUBIE_USER_ZDOTDIR:-$HOME}}/.zprofile" && "$KUBIE_LOGIN_SHELL" == "1" ]] ; then
     source "${{_KUBIE_USER_ZDOTDIR:-$HOME}}/.zprofile"
 fi


### PR DESCRIPTION
As upstream doc of zsh says, if a user has set ZDOTDIR variable, then the shell tries read from that path as well

https://zsh.sourceforge.io/Doc/Release/Files.html