### PR TITLE
Support KUBECONFIG env var and XDG config for kubeconfig and settings discovery

### DIFF
--- a/src/kubeconfig.rs
+++ b/src/kubeconfig.rs
@@ -258,6 +258,8 @@ where
         users: vec![],
     };
 
+    let mut load_errors: Vec<String> = vec![];
+
     for path in kubeconfigs.into_iter() {
         let path = path.as_ref();
 
@@ -282,8 +284,16 @@ where
                     .extend(kubeconfig.users.drain(..).map(|x| Sourced::new(&path, x)));
             }
             Err(err) => {
-                eprintln!("Error loading kubeconfig {}: {}", path.display(), err);
+                load_errors.push(format!("Error loading kubeconfig {}: {}", path.display(), err));
             }
+        }
+    }
+
+    // Only print load errors when no contexts were found, to avoid
+    // noisy warnings about broken files when valid configs exist.
+    if installed.contexts.is_empty() {
+        for err in &load_errors {
+            eprintln!("{}", err);
         }
     }
 


### PR DESCRIPTION
I am heavily using mise for my workflow on project based directories. I love the kubie approach but it wasn"t able to check my KUBECONFIG variable or a custom directory on the fly. I know there is some similar change asking for the support of the XDG_CONFIG_HOME (https://github.com/sbstp/kubie/pull/140) which seems to be on purpose. But maybe enabling it optionally is an option? 

 - KUBECONFIG env var support — kubie now reads the KUBECONFIG environment variable (colon-separated paths) to discover both kubeconfig files and kubie's own settings (kubie.yaml/kubie.yml). Entries can
  be files or directories.
  - XDG Base Directory support — kubie settings are also looked up at $XDG_CONFIG_HOME/kubie/kubie.yaml (defaults to ~/.config/kubie/), falling back to the original ~/.kube/kubie.yaml.
  - Quieter error output — kubeconfig load errors are now deferred and only printed when no valid contexts are found, avoiding noisy warnings when some configs are broken but others work.

  Settings lookup order

  1. KUBECONFIG entries (direct file or directory containing kubie.yaml)
  2. $XDG_CONFIG_HOME/kubie/kubie.yaml
  3. ~/.kube/kubie.yaml (original default)
