### PR TITLE
fix: handle kubectl connection error in ns selection

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Cursor, IsTerminal};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use skim::prelude::{Key, SkimItemReader};
 use skim::{Skim, SkimOptions};
 
@@ -60,7 +60,10 @@ pub fn select_or_list_context(skim_options: &SkimOptions, installed: &mut Instal
 }
 
 pub fn select_or_list_namespace(skim_options: &SkimOptions, namespaces: Option<Vec<String>>) -> Result<SelectResult> {
-    let mut namespaces = namespaces.unwrap_or_else(|| kubectl::get_namespaces(None).expect("could not get namespaces"));
+    let mut namespaces = match namespaces {
+        Some(ns) => ns,
+        None => kubectl::get_namespaces(None).context("Could not get namespaces")?,
+    };
 
     namespaces.sort();
 

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -30,7 +30,7 @@ pub fn get_namespaces<'a>(kubeconfig: impl Into<Option<&'a KubeConfig>>) -> anyh
     let result = cmd.output()?;
     if !result.status.success() {
         let stderr = str::from_utf8(&result.stderr).unwrap_or("could not decode stderr of kubectl as utf-8");
-        return Err(anyhow!("Error calling kubectl: {}", stderr));
+        return Err(anyhow!("Error calling kubectl:\n{}", stderr));
     }
 
     let text = str::from_utf8(&result.stdout)?;


### PR DESCRIPTION
Properly handle error like this in namespace selector on unreachable cluster:
```
thread 'main' panicked at src/cmd/mod.rs:63:85:
could not get namespaces: Error calling kubectl: E0325 11:02:21.550449   92901 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://127.0.0.1:26443/api?timeout=32s\": dial tcp 127.0.0.1:26443: connect: connection refused"
```