### PR TITLE
fix: check stop_ctx instead of start_ctx for bash exit hook

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -80,7 +80,7 @@ unset KUBIE_PROMPT
     let mut child = cmd.spawn()?;
     child.wait()?;
 
-    if !info.settings.hooks.start_ctx.is_empty() {
+    if !info.settings.hooks.stop_ctx.is_empty() {
         let temp_exit_hook_file = tempfile::Builder::new()
             .prefix("kubie-bash-exit-hook")
             .suffix(".bash")

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -39,7 +39,7 @@ fi
 
 # If a zsh_history file exists, copy it over before zsh initialization so history is maintained
 if [[ -f "$HOME/.zsh_history" ]] ; then
-    cp $HOME/.zsh_history $ZDOTDIR
+    cp "$HOME/.zsh_history" "$ZDOTDIR"
 fi
 
 KUBIE_LOGIN_SHELL=0


### PR DESCRIPTION
`sh.rs:83` — Wrong hook checked for exit/stop behavior
```rs
    if !info.settings.hooks.start_ctx.is_empty() {  // <-- checks start_ctx
    ...
    write!(temp_exit_hook_file_buf, "{}", info.settings.hooks.stop_ctx)?;  // <-- but runs stop_ctx
```
  It checks start_ctx to decide whether to run the stop_ctx hook. Compare with `zsh.rs:148` which correctly checks stop_ctx:
```rs
  if !info.settings.hooks.stop_ctx.is_empty() {
```
                                                

